### PR TITLE
Remove the :output-dir option from sass/build

### DIFF
--- a/config/org/arachne_framework/template/enterprise_spa.clj
+++ b/config/org/arachne_framework/template/enterprise_spa.clj
@@ -43,8 +43,7 @@
 
 (a/id ::sass-build
   (sass/build {:entrypoint "app.scss"
-               :output-to "app.css"
-               :output-dir "css"
+               :output-to "css/app.css"
                :source-map (dev?)
                :precision 6}))
 


### PR DESCRIPTION
This updates this template to the new arachne-sass module without the :output-dir